### PR TITLE
Temp comment out on push logic for test-action

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -6,10 +6,11 @@ name: Test Github Action
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  # 8-28-25: These should probably be commented back in at some point, but I'm doing PR related testing and this is just static.
+  # push:
+  #   branches: [ "main" ]
+  # pull_request:
+  #   branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Two birds: Less static for PR-testing logic I'm in the middle of, and since this is a PR helps test the PR action