### PR TITLE
Branch prot logic scaff

### DIFF
--- a/.github/workflows/get-branch-protection-rules.yml
+++ b/.github/workflows/get-branch-protection-rules.yml
@@ -1,0 +1,26 @@
+name: Get Branch Protection Rules
+
+on:
+
+  # This workflow should only ever be run manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      get_rules_for:
+        description: Name of branch to check for protection rules
+        type: choice
+        options: 
+          - 'main'
+          - 'env/qa1'
+          - 'all branches with rules'
+        default: 'main'
+
+jobs:
+  get-branch-protection-rules:
+    name: Get Branch Protection Rules (Job)
+    runs-on: ubuntu-latest
+    # permissions: 
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run get-branch-prot-rules script
+        run: ./shell-scripts/get-branch-prot-rules.sh 

--- a/shell-scripts/get-branch-prot-rules.sh
+++ b/shell-scripts/get-branch-prot-rules.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "You picked ${{ github.event.inputs.get_rules_for }}"


### PR DESCRIPTION
Adds .github/workflows/get-branch-protection-rules.yml which is a new manually run action to get branch protection rules

Adds shell-scripts/get-branch-prot-rules.sh which will be used to get branch protection rules and provide them to the action. very basic script at the moment