### PR TITLE
Feature/matt team luigi sc build

### DIFF
--- a/.github/workflows/sc-team-luigi-naming.yml
+++ b/.github/workflows/sc-team-luigi-naming.yml
@@ -88,6 +88,6 @@ jobs:
                 exit 1
             fi
         
-        # - name: "Failure: Comment on PR"
-        #   if: failure()
-        #   run: gh pr comment ${{ github.event.number }} -b "ERROR! The pull request cannot be merged. Branches being merged into ${{ github.base_ref }} must have the format of 'feature/team-luigi/*' (where * is the rest of your feature branch name)."
+        - name: "Failure: Comment on PR"
+          if: failure()
+          run: gh pr comment ${{ github.event.number }} -b "ERROR! The pull request cannot be merged. Branches being merged into ${{ github.base_ref }} must have the format of 'feature/team-luigi/*' (where * is the rest of your feature branch name)."


### PR DESCRIPTION
Adds sc-team-luigi-naming.yml workflow, which functions as a status check. When combined correctly with a branch protection rule, this workflow will not allow PRs to any team-luigi branch to be merged unless the source branch follows a specific naming convention (source branch must start with 'feature/team-luigi')